### PR TITLE
Fix #29 crash, add command line options to control user filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download the latest release: `procexp` from https://github.com/wolfc01/procexp/a
    sudo dnf install python3-pip
    ```   
 
-## Start Process Explorer: 
+## Start Process Explorer:
 
 _As a non-superuser user:_
 
@@ -53,6 +53,14 @@ _As a non-superuser user:_
    cd procexp-master
    ~/procexp/bin/python3 ./procexp.py
    ```
+
+### Command line options
+
+| Option | Description |
+|---|---|
+| `--user USER` | Show processes of USER (name or UID) instead of the current user |
+| `--all-users` | Show processes from all users on startup |
+| `-h`, `--help` | Show help message and exit |
 
 ## UNINSTALL
 

--- a/procexp.py
+++ b/procexp.py
@@ -24,10 +24,17 @@
 
 #create qt app early, in order to show unhandled exceptions graphically.
 import sys
+import argparse
+import pwd
 from PyQt6 import QtCore, QtGui, uic, QtWidgets
 import utils.procutils
 
-app = QtWidgets.QApplication(sys.argv)
+parser = argparse.ArgumentParser(description="Process Explorer for Linux")
+parser.add_argument("--user", metavar="USER", help="show processes of USER (name or UID) instead of the current user")
+parser.add_argument("--all-users", action="store_true", help="show processes from all users on startup")
+args, qt_args = parser.parse_known_args()
+
+app = QtWidgets.QApplication([sys.argv[0]] + qt_args)
 
 import procreader.reader
 import logui
@@ -61,6 +68,16 @@ class procexp:
     self._toplevelItems = {}
     self._mainUi = None
     self._onlyUser = True
+    self._filterUID = os.geteuid()
+
+    if args.all_users:
+      self._onlyUser = False
+    elif args.user is not None:
+      try:
+        self._filterUID = int(args.user)
+      except ValueError:
+        self._filterUID = pwd.getpwnam(args.user).pw_uid
+
     self._greenTopLevelItems = {}
     self._redTopLevelItems = {}
     self._singleProcessUiList = {}
@@ -112,7 +129,7 @@ class procexp:
     self._timer.start(int(self._settings["updateTimer"]))
 
     if self._onlyUser:
-      self._reader.setFilterUID(os.geteuid())
+      self._reader.setFilterUID(self._filterUID)
 
     self._systemOverviewUi = systemoverview.systemOverviewUi(self._reader.getCpuCount(), int(self._settings["historySampleCount"]), self._reader)
     self._networkOverviewUi = networkoverview.networkOverviewUi(self._reader.getNetworkCards(), int(self._settings["historySampleCount"]), self._reader)
@@ -144,7 +161,7 @@ class procexp:
         self.clearTree()
         self._onlyUser = False
       else:
-        self._reader.setFilterUID(os.geteuid())
+        self._reader.setFilterUID(self._filterUID)
         self.clearTree()
         self._onlyUser = True
     elif action is self._mainUi.actionProperties:

--- a/procexp.py
+++ b/procexp.py
@@ -303,7 +303,7 @@ class procexp:
     self._mainUi.menuProcess.exec(self._mainUi.processTreeWidget.mapToGlobal(point))
 
   def onHeaderContextMenu(self, point):
-    menu = QtGui.QMenu()
+    menu = QtWidgets.QMenu()
     for idx, col in enumerate(self._treeViewcolumns):
       action = QtGui.QAction(col, self._mainUi.processTreeWidget)
       action.setCheckable(True)

--- a/procexp.py
+++ b/procexp.py
@@ -156,7 +156,7 @@ class procexp:
       process = selectedItem.data(1,0)
       self.killProcessTree(process, self._procList)
     elif action is self._mainUi.actionShow_process_from_all_users:
-      if self._onlyUser:
+      if action.isChecked():
         self._reader.noFilterUID()
         self.clearTree()
         self._onlyUser = False
@@ -347,6 +347,7 @@ class procexp:
     mainUi.menuProcess.triggered.connect(self.performMenuAction)
     mainUi.menuOptions.triggered.connect(self.performMenuAction)
     mainUi.menuSettings.triggered.connect(self.performMenuAction)
+    mainUi.actionShow_process_from_all_users.setChecked(not self._onlyUser)
     mainUi.menuView.triggered.connect(self.performMenuAction)
     mainUi.menuHelp.triggered.connect(self.performMenuAction)
     

--- a/procreader/reader.py
+++ b/procreader/reader.py
@@ -684,6 +684,8 @@ class procreader(object):
     for line in data:
       cardName = line.split(":")[0].strip()
       if len(cardName) > 0:
+        if cardName not in self.__networkCards__:
+          self.__networkCards__[cardName] = {"actual": [0, 0, 0, 0], "speed": None}
         splittedLine = line.split(":")[1].split()
         recv = int(splittedLine[0])
         sent = int(splittedLine[8])

--- a/ui/main.ui
+++ b/ui/main.ui
@@ -273,6 +273,9 @@
    </property>
   </action>
   <action name="actionShow_process_from_all_users">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Show process from all users</string>
    </property>


### PR DESCRIPTION
* Fixes #29 so right-clicking header rows works again.
* Adds command line arguments `--all-users` (to preset the "Show processes from all users" option) and `--user` (to specify a user to filter for which can be different from the current EUID).
* Makes the menu option "Show processes from all users" show its state as checkbox.
* Prevents crashes when new network interfaces appear.